### PR TITLE
gamepad: add direct player controls

### DIFF
--- a/gamepad/gamepad.js
+++ b/gamepad/gamepad.js
@@ -44,7 +44,10 @@
 		DPadUp: () => simulateKeyPress("ArrowUp"),
 		DPadDown: () => simulateKeyPress("ArrowDown"),
 		DPadLeft: () => simulateKeyPress("ArrowLeft"),
-		DPadRight: () => simulateKeyPress("ArrowRight")
+		DPadRight: () => simulateKeyPress("ArrowRight"),
+		Start: () => Spicetify.Player.togglePlay(),
+		LStick: () => Spicetify.Player.back(),
+		RStick: () => Spicetify.Player.next()
 	};
 
 	let overlayVisible = false;

--- a/gamepad/gamepad.js
+++ b/gamepad/gamepad.js
@@ -45,9 +45,7 @@
 		DPadDown: () => simulateKeyPress("ArrowDown"),
 		DPadLeft: () => simulateKeyPress("ArrowLeft"),
 		DPadRight: () => simulateKeyPress("ArrowRight"),
-		Start: () => Spicetify.Player.togglePlay(),
-		LStick: () => Spicetify.Player.back(),
-		RStick: () => Spicetify.Player.next()
+		Start: () => Spicetify.Player.togglePlay()
 	};
 
 	let overlayVisible = false;


### PR DESCRIPTION
For now with only a pause/play button.

To-do:
- Add back / forward buttons
- Add new controls to the Gamepad Controls element