### PR TITLE
Make Notification displayed upon failed local restore more verbose

### DIFF
--- a/spotifyBackup/spotifyBackup.js
+++ b/spotifyBackup/spotifyBackup.js
@@ -102,7 +102,7 @@
 				let parsedBackupData = JSON.parse(await Spicetify.Platform.ClipboardAPI.paste());
 				restoreData(parsedBackupData);
 			} catch (error) {
-				Spicetify.showNotification("Failed to restore data.", true);
+				Spicetify.showNotification("Failed to restore data from clipboard.", true);
 				console.error("Local restore failed:", error);
 			}
 		} else {


### PR DESCRIPTION
Recently came across this extension and wasn't immediately aware you had to have the backup file in your clipboard, so I thought I'd make the error more verbose so it's clear that it wasn't possible to get the backup from the clipboard.