### PR TITLE
fix(quickQueue): make it work in search results

### DIFF
--- a/quickQueue/quickQueue.js
+++ b/quickQueue/quickQueue.js
@@ -249,7 +249,15 @@
 						queueButtonWrapper.style.display = "contents";
 						queueButtonWrapper.style.marginRight = 0;
 
-						const queueButtonElement = insertionParent.insertBefore(queueButtonWrapper, referenceNode);
+						// Safely insert: only use insertBefore if the reference node belongs to the same parent
+						let queueButtonElement;
+						if (referenceNode && referenceNode.parentNode === insertionParent) {
+							queueButtonElement = insertionParent.insertBefore(queueButtonWrapper, referenceNode);
+						} else if (insertionParent.firstChild) {
+							queueButtonElement = insertionParent.insertBefore(queueButtonWrapper, insertionParent.firstChild);
+						} else {
+							queueButtonElement = insertionParent.appendChild(queueButtonWrapper);
+						}
 						Spicetify.ReactDOM.render(
 							Spicetify.React.createElement(QueueButton, {
 								uri,


### PR DESCRIPTION
It previously raised this exception on search with left alignment enabled

```
Uncaught NotFoundError: Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.
    at quickQueue.js:283:50
    at NodeList.forEach (<anonymous>)
    at quickQueue.js:209:24
    at Array.forEach (<anonymous>)
    at MutationObserver.<anonymous> (quickQueue.js:208:16)
```

<img width="491" height="216" alt="image" src="https://github.com/user-attachments/assets/4ef2d118-ee7e-4a2f-92e5-968b20c7d83d" />
