### PR TITLE
Fix styles for right sidebar in now playing view

### DIFF
--- a/npvAmbience/npvAmbience.js
+++ b/npvAmbience/npvAmbience.js
@@ -50,6 +50,29 @@
 		.Root__right-sidebar aside:has(.xjf0Pj3YnoegOkJUpaPS) .wfJD_yK4h7xnpTmrh62U {
 			padding-top: 64px;
 		}
+		
+
+		/* compatibility: spotify=1.2.51; spicetify v2.38.5 */
+		.Root__right-sidebar aside .W3E0IT3_STcazjTeyOJa {
+			position: absolute;
+			width: 100%;
+			z-index: 1;
+			background: transparent;
+			transition: background-color 0.25s, backdrop-filter 0.5s, opacity 0.4s ease-out;
+		}
+
+		.Root__right-sidebar aside .W3E0IT3_STcazjTeyOJa.mdMUqcSHFw1lZIcYEblu {
+			height: 63px;
+			background-color: rgba(var(--spice-rgb-main), 0.2) !important;
+			backdrop-filter: blur(24px) saturate(140%) brightness(0.6);
+			border-bottom: 1px solid rgba(var(--spice-rgb-selected-row),0.2);
+		}
+
+		.Root__right-sidebar aside:has(.W3E0IT3_STcazjTeyOJa) .zduvaX0Ioxqd5ypeWoAf {
+			padding-top: 64px;
+		}
+		/*  */
+
 
 		. Root__right-sidebar aside {
 			--background-base: var(--spice-main) !important;

--- a/npvAmbience/npvAmbience.js
+++ b/npvAmbience/npvAmbience.js
@@ -32,24 +32,25 @@
 			filter: blur(40px) contrast(2);
 		}
 
-		aside[aria-label="Now playing view"] .ZbDMGdU4aBOnrNLowNRq, aside[aria-label="Now playing view"] .W3E0IT3_STcazjTeyOJa {
+		.Root__right-sidebar aside .xjf0Pj3YnoegOkJUpaPS {
 			position: absolute;
 			width: 100%;
 			z-index: 1;
 			background: transparent;
 			transition: background-color 0.25s, backdrop-filter 0.5s, opacity 0.4s ease-out;
 		}
-		aside[aria-label="Now playing view"] .fAte2d0xETy7pnDUAgHY, aside[aria-label="Now playing view"] .mdMUqcSHFw1lZIcYEblu {
+
+		.Root__right-sidebar aside .xjf0Pj3YnoegOkJUpaPS.EnViFhuIR5WVeEopJHu3 {
 			background-color: rgba(var(--spice-rgb-main), 0.2) !important;
-			backdrop-filter: blur(24px) saturate(140%);
+			backdrop-filter: blur(24px) saturate(140%) brightness(0.6);
 			border-bottom: 1px solid rgba(var(--spice-rgb-selected-row),0.2);
 		}
 
-		aside[aria-label="Now playing view"]:has(.ZbDMGdU4aBOnrNLowNRq) .main-buddyFeed-scrollBarContainer:not(:has(.main-buddyFeed-content > .main-buddyFeed-header)), aside[aria-label="Now playing view"]:has(.W3E0IT3_STcazjTeyOJa) .cZCuJDjrGA2QMXja_Sua:not(:has(.AAdBM1nhG73supMfnYX7 > .fNXmHtlrj4UVWmhQrJ_5)) {
+		.Root__right-sidebar aside:has(.xjf0Pj3YnoegOkJUpaPS) .wfJD_yK4h7xnpTmrh62U {
 			padding-top: 64px;
 		}
 
-		aside[aria-label="Now playing view"] {
+		. Root__right-sidebar aside {
 			--background-base: var(--spice-main) !important;
 		}
 

--- a/npvAmbience/npvAmbience.js
+++ b/npvAmbience/npvAmbience.js
@@ -41,6 +41,7 @@
 		}
 
 		.Root__right-sidebar aside .xjf0Pj3YnoegOkJUpaPS.EnViFhuIR5WVeEopJHu3 {
+			height: 63px;
 			background-color: rgba(var(--spice-rgb-main), 0.2) !important;
 			backdrop-filter: blur(24px) saturate(140%) brightness(0.6);
 			border-bottom: 1px solid rgba(var(--spice-rgb-selected-row),0.2);


### PR DESCRIPTION
This fix for Issue #49

about:
- update css to use current class names (.xjf0Pj3YnoegOkJUpaPS, .EnViFhuIR5WVeEopJHu3, .wfJD_yK4h7xnpTmrh62U) and use root patch instead catching
- add dimming on top bar with brightness(0.6) (this looks cooler + icons and text are now more visible on very light background of album cover)

upd: fix 1px shadow offset by reducing size of _only background underlayer_, not entire element container (unrelated to `border-bottom: 1px](border-bottom: 1px solid rgba(var(--spice-rgb-selected-row),0.2);` - something else are broken):

before ↓
<img width="362" alt="before" src="https://github.com/user-attachments/assets/8e26c35b-3a4f-4d44-995d-dec4f2069bbb" />
<img width="362" alt="after" src="https://github.com/user-attachments/assets/f7dd4fae-3ecf-4fc0-a794-cc35c45964ff" />
after ↑
